### PR TITLE
chore: Deprecated xacro tag 'insert_block'

### DIFF
--- a/robots/mpo_700/xacros/depth_camera.xacro
+++ b/robots/mpo_700/xacros/depth_camera.xacro
@@ -5,7 +5,7 @@
 	  	<xacro:property name="depth_camera_link" value="0.05" />
 		    <joint name="${name}_joint" type="fixed">
 		      <axis xyz="0 1 0" />
-		      <insert_block name="origin" />
+		      <xacro:insert_block name="origin" />
 		      <parent link="${parent}"/>
 		      <child link="${name}_link"/>
 		    </joint>

--- a/robots/mpo_700/xacros/docking_adapter.xacro
+++ b/robots/mpo_700/xacros/docking_adapter.xacro
@@ -3,7 +3,7 @@
   <xacro:macro name="docking_adapter" params="name parent *origin">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/robots/mpo_700/xacros/imu.xacro
+++ b/robots/mpo_700/xacros/imu.xacro
@@ -4,7 +4,7 @@
   <xacro:macro name="imu" params="name parent *origin">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/robots/mpo_700/xacros/micro_scan.xacro
+++ b/robots/mpo_700/xacros/micro_scan.xacro
@@ -3,7 +3,7 @@
   <xacro:macro name="sick_laser_v0" params="name parent *origin ros_topic">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/robots/mpo_700/xacros/mpo_700_body.xacro
+++ b/robots/mpo_700/xacros/mpo_700_body.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="mpo_700_base" params="name parent *origin">
    <joint name="${name}_joint" type="fixed">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 -1" />
     <!-- <limit effort="1000.0" lower="-1e+16" upper="1e+16" velocity="3.5"/> -->
     <joint_properties damping="1" friction="1" />

--- a/robots/mpo_700/xacros/mpo_700_caster.xacro
+++ b/robots/mpo_700/xacros/mpo_700_caster.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="mpo_700_caster_0" params="name parent *origin">
    <joint name="${name}_joint" type="fixed">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 -1" />
     <!-- <limit effort="1000.0" lower="-1e+16" upper="1e+16" velocity="3.5"/> -->
     <joint_properties damping="1" friction="1" />
@@ -37,7 +37,7 @@
 
   <xacro:macro name="mpo_700_caster_1" params="name parent *origin">
    <joint name="${name}_joint" type="fixed">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 -1" />
     <joint_properties damping="1" friction="1" />
     <parent link="${parent}" />
@@ -70,7 +70,7 @@
   
   <xacro:macro name="mpo_700_caster_2" params="name parent *origin">
    <joint name="${name}_joint" type="fixed">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 -1" />
     <joint_properties damping="1" friction="1" />
     <parent link="${parent}" />
@@ -103,7 +103,7 @@
 
   <xacro:macro name="mpo_700_caster_3" params="name parent *origin">
    <joint name="${name}_joint" type="fixed">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 -1" />
     <joint_properties damping="1" friction="1" />
     <parent link="${parent}" />

--- a/robots/mpo_700/xacros/mpo_700_caster_left.xacro
+++ b/robots/mpo_700/xacros/mpo_700_caster_left.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="mpo_700_caster_left" params="name parent *origin">
    <joint name="${name}_joint" type="revolute">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 1" />
     <limit effort="1000.0" lower="-1e+16" upper="1e+16" velocity="6.5"/>
     <joint_properties damping="30" friction="110"/>

--- a/robots/mpo_700/xacros/mpo_700_caster_right.xacro
+++ b/robots/mpo_700/xacros/mpo_700_caster_right.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="mpo_700_caster_right" params="name parent *origin">
    <joint name="${name}_joint" type="revolute">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <axis xyz="0 0 1" />
     <limit effort="1000.0" lower="-1e+16" upper="1e+16" velocity="6.5"/>
     <joint_properties damping="30" friction="110"/>

--- a/robots/mpo_700/xacros/mpo_700_wheel.xacro
+++ b/robots/mpo_700/xacros/mpo_700_wheel.xacro
@@ -3,7 +3,7 @@
 
   <xacro:macro name="mpo_700_wheel" params="name parent *origin">
    <joint name="${name}_joint" type="revolute">
-    <insert_block name="origin" />
+    <xacro:insert_block name="origin" />
     <limit effort="1000.0" lower="-1e+16" upper="1e+16" velocity="20.5"/>
     <axis xyz="0 -1 0" />
     <joint_properties damping="30" friction="110"/>

--- a/robots/mpo_700/xacros/sick_S300.xacro
+++ b/robots/mpo_700/xacros/sick_S300.xacro
@@ -3,7 +3,7 @@
   <xacro:macro name="sick_laser_v0" params="name parent *origin ros_topic">
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>

--- a/robots/mpo_700/xacros/ultrasonic.xacro
+++ b/robots/mpo_700/xacros/ultrasonic.xacro
@@ -5,7 +5,7 @@
 
     <joint name="${name}_joint" type="fixed">
       <axis xyz="0 1 0" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
       <child link="${name}_link"/>
     </joint>


### PR DESCRIPTION
Remove annoying warning message when starting gazebo:
"Deprecated: xacro tag 'insert_block' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)"